### PR TITLE
Fix #3 #4 #5: Thread safety, resource leaks, and waveform UI performance

### DIFF
--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -51,6 +51,9 @@ void AudioEngine::getNextAudioBlock(const juce::AudioSourceChannelInfo& bufferTo
         int numSamplesToFill = bufferToFill.numSamples;
         int numChannels = juce::jmin(outputBuffer->getNumChannels(), recordedBuffer.getNumChannels());
         
+        // Lock to prevent concurrent modification from loadFileToBuffer/loadFileToSlot
+        juce::SpinLock::ScopedLockType lock(bufferLock);
+        
         for (int sample = 0; sample < numSamplesToFill; ++sample)
         {
             // 線形補間のためのインデックスと係数を計算
@@ -100,6 +103,9 @@ void AudioEngine::recordAudioBlock(const juce::AudioSourceChannelInfo& bufferToF
     int numSamples = bufferToFill.numSamples;
     int numChannels = juce::jmin(inputBuffer->getNumChannels(), recordedBuffer.getNumChannels());
     
+    // Lock to prevent concurrent startRecording/stopRecording/loadFileToBuffer
+    juce::SpinLock::ScopedLockType lock(bufferLock);
+    
     // バッファに余裕があれば書き込み
     if (recordWritePosition + numSamples <= recordedBuffer.getNumSamples())
     {
@@ -113,18 +119,22 @@ void AudioEngine::recordAudioBlock(const juce::AudioSourceChannelInfo& bufferToF
     else
     {
         // バッファがいっぱいになったら録音停止
-        stopRecording();
+        recordingState = false;
+        playbackPosition = 0.0;
+        sendChangeMessage();
     }
 }
 
 void AudioEngine::loadFile(const juce::File& file)
 {
-    auto* reader = formatManager.createReaderFor(file);
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
     if (reader != nullptr)
     {
-        std::unique_ptr<juce::AudioFormatReaderSource> newSource(new juce::AudioFormatReaderSource(reader, true));
+        std::unique_ptr<juce::AudioFormatReaderSource> newSource(
+            new juce::AudioFormatReaderSource(reader.get(), false)); // don't take ownership yet
         transportSource.setSource(newSource.get(), 0, nullptr, reader->sampleRate);
         readerSource.reset(newSource.release());
+        readerSource->setReader(reader.release(), true); // now transfer ownership
         
         resamplerSource.reset(new juce::ResamplingAudioSource(&transportSource, false, 2));
         
@@ -158,17 +168,23 @@ void AudioEngine::setCrossfaderGain(float gain)
 
 void AudioEngine::startRecording()
 {
-    recordWritePosition = 0;
-    recordedBuffer.clear();
-    recordingState = true;
-    playing = false; // 録音中は再生停止
+    {
+        juce::SpinLock::ScopedLockType lock(bufferLock);
+        recordWritePosition = 0;
+        recordedBuffer.clear();
+        recordingState = true;
+        playing = false; // 録音中は再生停止
+    }
     sendChangeMessage();
 }
 
 void AudioEngine::stopRecording()
 {
-    recordingState = false;
-    playbackPosition = 0.0;
+    {
+        juce::SpinLock::ScopedLockType lock(bufferLock);
+        recordingState = false;
+        playbackPosition = 0.0;
+    }
     sendChangeMessage();
 }
 
@@ -248,22 +264,24 @@ juce::File AudioEngine::saveRecordingToFile()
 
 void AudioEngine::loadFileToBuffer(const juce::File& file)
 {
-    auto* reader = formatManager.createReaderFor(file);
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
     if (reader != nullptr)
     {
-        // 録音バッファにファイルの内容をロード
-        int numSamples = static_cast<int>(reader->lengthInSamples);
-        int numChannels = static_cast<int>(reader->numChannels);
-        
-        recordedBuffer.setSize(juce::jmax(2, numChannels), numSamples);
-        reader->read(&recordedBuffer, 0, numSamples, 0, true, true);
-        
-        recordWritePosition = numSamples;
-        currentSampleRate = reader->sampleRate;
-        playbackPosition = 0.0;
-        
-        delete reader;
-        
+        {
+            juce::SpinLock::ScopedLockType lock(bufferLock);
+            
+            // 録音バッファにファイルの内容をロード
+            int numSamples = static_cast<int>(reader->lengthInSamples);
+            int numChannels = static_cast<int>(reader->numChannels);
+            
+            recordedBuffer.setSize(juce::jmax(2, numChannels), numSamples);
+            reader->read(&recordedBuffer, 0, numSamples, 0, true, true);
+            
+            recordWritePosition = numSamples;
+            currentSampleRate = reader->sampleRate;
+            playbackPosition = 0.0;
+        }
+        // reader is automatically deleted by unique_ptr
         sendChangeMessage();
     }
 }
@@ -274,7 +292,7 @@ void AudioEngine::loadFileToSlot(int slotIndex, const juce::File& file)
 {
     if (slotIndex < 0 || slotIndex >= NUM_SLOTS) return;
     
-    auto* reader = formatManager.createReaderFor(file);
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
     if (reader != nullptr)
     {
         int numSamples = static_cast<int>(reader->lengthInSamples);
@@ -286,7 +304,7 @@ void AudioEngine::loadFileToSlot(int slotIndex, const juce::File& file)
         slot.numSamples = numSamples;
         slot.fileName = file.getFileNameWithoutExtension();
         
-        delete reader;
+        // reader is automatically deleted by unique_ptr
         
         // アクティブスロットならメインバッファにもコピー
         if (slotIndex == activeSlotIndex)
@@ -307,11 +325,14 @@ void AudioEngine::setActiveSlot(int slotIndex)
     const auto& slot = sampleSlots[static_cast<size_t>(slotIndex)];
     if (slot.numSamples > 0)
     {
-        // スロットのバッファをメイン再生バッファにコピー
-        recordedBuffer.makeCopyOf(slot.buffer);
-        recordWritePosition = slot.numSamples;
-        playbackPosition = 0.0;
-        
+        {
+            juce::SpinLock::ScopedLockType lock(bufferLock);
+            
+            // スロットのバッファをメイン再生バッファにコピー
+            recordedBuffer.makeCopyOf(slot.buffer);
+            recordWritePosition = slot.numSamples;
+            playbackPosition = 0.0;
+        }
         sendChangeMessage();
     }
 }

--- a/Source/AudioEngine.h
+++ b/Source/AudioEngine.h
@@ -82,6 +82,9 @@ public juce::ChangeBroadcaster
 	// Crossfader
 	juce::LinearSmoothedValue<float> crossfaderGain { 1.0f };
 
+	// Thread safety for recording buffer (audio callback vs main thread)
+	juce::SpinLock bufferLock;
+
 	// Recording buffer
 	bool recordingState = false;
 	juce::AudioBuffer<float> recordedBuffer;

--- a/Source/WaveformComponent.cpp
+++ b/Source/WaveformComponent.cpp
@@ -52,6 +52,8 @@ void WaveformComponent::paint(juce::Graphics& g)
 
 void WaveformComponent::resized()
 {
+	// Window resize requires full path rebuild
+	cachedBufferSize = 0;
 	updateWaveformPath();
 }
 
@@ -60,14 +62,10 @@ void WaveformComponent::timerCallback()
 	// 録音中または再生中は再描画
 	if (audioEngine.isRecording() || audioEngine.isPlaying())
 	{
-		// 録音中は波形を更新
+		// 録音中は差分更新のみ（UIスレッドブロック回避）
 		if (audioEngine.isRecording())
 		{
-			int currentSamples = audioEngine.getRecordedSamplesCount();
-			if (currentSamples != cachedBufferSize)
-			{
-				updateWaveformPath();
-			}
+			updateWaveformPath();
 		}
 		repaint();
 	}
@@ -75,7 +73,9 @@ void WaveformComponent::timerCallback()
 
 void WaveformComponent::changeListenerCallback(juce::ChangeBroadcaster* source)
 {
-	// 録音状態が変わったら波形を更新
+	juce::ignoreUnused(source);
+	// 録音状態が変わったらフル再構築（バッファ内容がリセットされる可能性がある）
+	cachedBufferSize = 0;
 	updateWaveformPath();
 	repaint();
 }
@@ -83,17 +83,56 @@ void WaveformComponent::changeListenerCallback(juce::ChangeBroadcaster* source)
 void WaveformComponent::setExpanded(bool shouldExpand)
 {
 	isExpanded = shouldExpand;
+	cachedBufferSize = 0;
 	resized();
 }
 
 void WaveformComponent::updateWaveformPath()
 {
+	const auto& buffer = audioEngine.getRecordedBuffer();
+	int numSamples = audioEngine.getRecordedSamplesCount();
+	
+	if (numSamples <= 0)
+	{
+		waveformPath.clear();
+		cachedBufferSize = 0;
+		cachedRecordedSamples = 0;
+		return;
+	}
+	
+	auto bounds = getLocalBounds().toFloat().reduced(2);
+	if (bounds.getWidth() <= 0 || bounds.getHeight() <= 0) return;
+	
+	int samplesPerPixel = juce::jmax(1, numSamples / static_cast<int>(bounds.getWidth()));
+	
+	// バッファサイズが変わった（setSize等）または初回はフル再構築
+	if (buffer.getNumSamples() != cachedBufferSize || cachedRecordedSamples == 0)
+	{
+		rebuildFullWaveformPath();
+		return;
+	}
+	
+	// 差分更新：新しく録音されたサンプルのみをスキャン
+	int newSamples = numSamples;
+	if (newSamples > cachedRecordedSamples)
+	{
+		appendWaveformPath(cachedRecordedSamples, newSamples);
+	}
+}
+
+void WaveformComponent::rebuildFullWaveformPath()
+{
+	const auto& buffer = audioEngine.getRecordedBuffer();
+	int numSamples = audioEngine.getRecordedSamplesCount();
+	
 	waveformPath.clear();
 	
-	const auto& buffer = audioEngine.getRecordedBuffer();
-	int numSamples = audioEngine.getRecordedSamplesCount(); // 実際に録音されたサンプル数を使用
-	
-	if (numSamples <= 0) return;
+	if (numSamples <= 0)
+	{
+		cachedBufferSize = buffer.getNumSamples();
+		cachedRecordedSamples = 0;
+		return;
+	}
 	
 	auto bounds = getLocalBounds().toFloat().reduced(2);
 	float width = bounds.getWidth();
@@ -105,6 +144,7 @@ void WaveformComponent::updateWaveformPath()
 	
 	const float* channelData = buffer.getReadPointer(0);
 	
+	// 上半分
 	waveformPath.startNewSubPath(bounds.getX(), centerY);
 	
 	for (int x = 0; x < static_cast<int>(width); ++x)
@@ -140,6 +180,61 @@ void WaveformComponent::updateWaveformPath()
 	
 	waveformPath.closeSubPath();
 	
-	cachedBufferSize = numSamples;
+	cachedBufferSize = buffer.getNumSamples();
+	cachedRecordedSamples = numSamples;
 }
 
+void WaveformComponent::appendWaveformPath(int fromSample, int toSample)
+{
+	const auto& buffer = audioEngine.getRecordedBuffer();
+	int numSamples = audioEngine.getRecordedSamplesCount();
+	
+	auto bounds = getLocalBounds().toFloat().reduced(2);
+	float width = bounds.getWidth();
+	float height = bounds.getHeight();
+	float centerY = bounds.getCentreY();
+	
+	int samplesPerPixel = juce::jmax(1, numSamples / static_cast<int>(width));
+	const float* channelData = buffer.getReadPointer(0);
+	
+	// 差分のみスキャン — 新しいピクセル範囲を計算
+	int fromPixel = fromSample / samplesPerPixel;
+	int toPixel = juce::jmin(static_cast<int>(width), (toSample + samplesPerPixel - 1) / samplesPerPixel);
+	
+	// 既存パスの最後のポイントを取得し、そこから続きを描画
+	// 上半分の新しいピクセルのみ更新
+	for (int x = fromPixel; x < toPixel; ++x)
+	{
+		int startSample = x * samplesPerPixel;
+		int endSample = juce::jmin(startSample + samplesPerPixel, toSample);
+		
+		float maxValue = 0.0f;
+		for (int i = startSample; i < endSample; ++i)
+		{
+			maxValue = juce::jmax(maxValue, std::abs(channelData[i]));
+		}
+		
+		float yTop = centerY - maxValue * (height / 2.0f) * 0.9f;
+		float yBot = centerY + maxValue * (height / 2.0f) * 0.9f;
+		
+		waveformPath.lineTo(bounds.getX() + static_cast<float>(x), yTop);
+	}
+	
+	// 下半分（ミラー）の差分 — reverse order
+	for (int x = toPixel - 1; x >= fromPixel; --x)
+	{
+		int startSample = x * samplesPerPixel;
+		int endSample = juce::jmin(startSample + samplesPerPixel, toSample);
+		
+		float maxValue = 0.0f;
+		for (int i = startSample; i < endSample; ++i)
+		{
+			maxValue = juce::jmax(maxValue, std::abs(channelData[i]));
+		}
+		
+		float yBot = centerY + maxValue * (height / 2.0f) * 0.9f;
+		waveformPath.lineTo(bounds.getX() + static_cast<float>(x), yBot);
+	}
+	
+	cachedRecordedSamples = toSample;
+}

--- a/Source/WaveformComponent.h
+++ b/Source/WaveformComponent.h
@@ -24,10 +24,14 @@ class WaveformComponent : public juce::Component,
 	void updateWaveformPath();
 
 	private:
+	void rebuildFullWaveformPath();
+	void appendWaveformPath(int fromSample, int toSample);
+
 	AudioEngine& audioEngine;
 	bool isExpanded = false;
 	juce::Path waveformPath;
-	int cachedBufferSize = 0;
+	int cachedBufferSize = 0;      // last total sample count when full path was built
+	int cachedRecordedSamples = 0; // samples already rendered into waveformPath
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WaveformComponent)
 };


### PR DESCRIPTION
## Summary

Fixes three high-priority issues in the audio engine and waveform rendering:

### #3 🐛 Thread safety in recording buffer writes
- **Problem:** `recordAudioBlock()` is called from the audio callback thread while `startRecording()`/`stopRecording()`/`loadFileToBuffer()` run on the main thread — no mutual exclusion.
- **Fix:** Added `juce::SpinLock` (`bufferLock`) protecting all shared state access. Lock is used in:
  - `recordAudioBlock()` — audio callback thread
  - `getNextAudioBlock()` — audio callback thread  
  - `startRecording()` / `stopRecording()` — main thread
  - `loadFileToBuffer()` / `setActiveSlot()` — main thread
- `sendChangeMessage()` is always called **outside** the lock to prevent deadlock with `ChangeListener` callbacks.

### #4 🐛 Resource leak in createReaderFor
- **Problem:** `loadFileToBuffer()` and `loadFileToSlot()` use raw `delete` on `AudioFormatReader*` — leaks if an exception occurs between `createReaderFor` and `delete`.
- **Fix:** Replaced raw pointers with `std::unique_ptr<juce::AudioFormatReader>` in `loadFile()`, `loadFileToBuffer()`, and `loadFileToSlot()`.

### #5 ⚡ Waveform drawing blocks UI thread
- **Problem:** `updateWaveformPath()` scans all 1.3M samples every 40ms (25fps) during recording — blocks the UI thread.
- **Fix:** Incremental path update during recording:
  - Only scans newly recorded samples (delta) instead of the entire buffer
  - Full rebuild only on buffer resize, window resize, or recording state change
  - Tracks `cachedBufferSize` and `cachedRecordedSamples` for efficient diff detection

## Files Changed
- `Source/AudioEngine.h` — Added `juce::SpinLock bufferLock`
- `Source/AudioEngine.cpp` — SpinLock guards, unique_ptr for readers, deadlock-safe messaging
- `Source/WaveformComponent.h` — Added `rebuildFullWaveformPath()`, `appendWaveformPath()` helpers
- `Source/WaveformComponent.cpp` — Incremental waveform rendering with diff detection

## Test Plan
- [ ] Record 30 seconds of audio — verify no UI stuttering during recording
- [ ] Load a file while recording is active — verify no crash
- [ ] Rapid start/stop recording — verify no race condition
- [ ] Load files into sample slots A/B/C/D — verify correct loading
- [ ] Verify waveform displays correctly after loading and recording

Closes #3, Closes #4, Closes #5