### PR TITLE
fix: createReaderFor のリソースリークを修正 (#4)

### DIFF
--- a/Source/AudioEngine.cpp
+++ b/Source/AudioEngine.cpp
@@ -248,7 +248,7 @@ juce::File AudioEngine::saveRecordingToFile()
 
 void AudioEngine::loadFileToBuffer(const juce::File& file)
 {
-    auto* reader = formatManager.createReaderFor(file);
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
     if (reader != nullptr)
     {
         // 録音バッファにファイルの内容をロード
@@ -262,8 +262,6 @@ void AudioEngine::loadFileToBuffer(const juce::File& file)
         currentSampleRate = reader->sampleRate;
         playbackPosition = 0.0;
         
-        delete reader;
-        
         sendChangeMessage();
     }
 }
@@ -274,7 +272,7 @@ void AudioEngine::loadFileToSlot(int slotIndex, const juce::File& file)
 {
     if (slotIndex < 0 || slotIndex >= NUM_SLOTS) return;
     
-    auto* reader = formatManager.createReaderFor(file);
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
     if (reader != nullptr)
     {
         int numSamples = static_cast<int>(reader->lengthInSamples);
@@ -285,8 +283,6 @@ void AudioEngine::loadFileToSlot(int slotIndex, const juce::File& file)
         reader->read(&slot.buffer, 0, numSamples, 0, true, true);
         slot.numSamples = numSamples;
         slot.fileName = file.getFileNameWithoutExtension();
-        
-        delete reader;
         
         // アクティブスロットならメインバッファにもコピー
         if (slotIndex == activeSlotIndex)


### PR DESCRIPTION
## 概要

Issue #4 で報告された `createReaderFor` のリソースリークを修正します。

## 問題

`loadFileToBuffer()` と `loadFileToSlot()` で `formatManager.createReaderFor()` の戻り値を生ポインタで管理し、手動 `delete` で解放していました。これにより、`reader->read()` 等で例外が発生した場合にリソースリークが発生します。

## 修正内容

- `auto* reader` → `std::unique_ptr<juce::AudioFormatReader> reader` に変更
- 手動 `delete reader` を削除（RAII によりスコープ退出時に自動解放）
- 例外安全性を確保（exception-safe）

## 変更ファイル

- `Source/AudioEngine.cpp`（2箇所）

## テスト

JUCE フレームワーク依存のためビルド環境でのコンパイル確認は保留。変更は純粋な所有権管理の変更のみで、ロジックは一切変更していません。

Closes #4