### PR TITLE
Fix #5: 波形描画のUIスレッドブロックを解消

### DIFF
--- a/Source/WaveformComponent.cpp
+++ b/Source/WaveformComponent.cpp
@@ -1,145 +1,373 @@
 /*
  ==============================================================================
  WaveformComponent.cpp
+
+ Issue #5 Fix: Move waveform path computation off the UI thread.
+ 
+ Problem: updateWaveformPath() scanned up to 1.3M samples on the message
+ thread at 25 fps during recording, causing UI stalls.
+
+ Solution:
+ - Use juce::AudioThumbnail for efficient, background-thread thumbnail
+   generation when available (file loads).
+ - During live recording, rebuild the path only when the sample count has
+   changed by a meaningful threshold (REBUILD_THRESHOLD_SAMPLES) and do
+   the heavy scan on a background thread via juce::ThreadPool.
+ - Thread-safe double-buffered path cache (activeCache / pendingCache)
+   protected by juce::SpinLock so paint() never blocks on path generation.
+ - On recording completion, do a single full rebuild and cache the result.
  ==============================================================================
  */
 #include "WaveformComponent.h"
 
+// ---------------------------------------------------------------------------
+// Construction / Destruction
+// ---------------------------------------------------------------------------
+
 WaveformComponent::WaveformComponent(AudioEngine& engine)
-: audioEngine(engine)
+    : audioEngine(engine)
 {
-	// AudioEngineの変更を監視
-	audioEngine.addChangeListener(this);
-	startTimer(40); // 25fps
+    audioEngine.addChangeListener(this);
+    startTimer(40); // 25 fps
 }
 
 WaveformComponent::~WaveformComponent()
 {
-	audioEngine.removeChangeListener(this);
-	stopTimer();
+    audioEngine.removeChangeListener(this);
+    stopTimer();
 }
+
+// ---------------------------------------------------------------------------
+// paint — only reads from activeCache (fast, lock-free when no swap)
+// ---------------------------------------------------------------------------
 
 void WaveformComponent::paint(juce::Graphics& g)
 {
-	auto bounds = getLocalBounds().toFloat();
-	
-	// 背景
-	g.setColour(juce::Colour::fromString("FF1E293B")); // Slate 800
-	g.fillRoundedRectangle(bounds, 5.0f);
-	
-	if (!audioEngine.hasRecordedAudio())
-	{
-		// 録音がない場合のメッセージ
-		g.setColour(juce::Colours::grey);
-		g.drawText("No recording - Press REC to start", bounds, juce::Justification::centred);
-		return;
-	}
-	
-	// 波形の描画
-	g.setColour(juce::Colour::fromString("FF22C55E")); // 緑
-	g.strokePath(waveformPath, juce::PathStrokeType(1.5f));
-	
-	// 再生位置インジケーター
-	if (audioEngine.hasRecordedAudio())
-	{
-		double pos = audioEngine.getPlaybackPosition();
-		float x = bounds.getX() + static_cast<float>(pos) * bounds.getWidth();
-		
-		g.setColour(juce::Colours::white);
-		g.drawLine(x, bounds.getY(), x, bounds.getBottom(), 2.0f);
-	}
+    auto bounds = getLocalBounds().toFloat();
+
+    // 背景
+    g.setColour(juce::Colour::fromString("FF1E293B")); // Slate 800
+    g.fillRoundedRectangle(bounds, 5.0f);
+
+    if (!audioEngine.hasRecordedAudio())
+    {
+        g.setColour(juce::Colours::grey);
+        g.drawText("No recording - Press REC to start", bounds, juce::Justification::centred);
+        return;
+    }
+
+    // スレッド安全にキャッシュされたPathを取得
+    juce::Path pathToDraw;
+    {
+        juce::SpinLock::ScopedLockType lock(cacheLock);
+        pathToDraw = activeCache.path;
+    }
+
+    if (!pathToDraw.isEmpty())
+    {
+        g.setColour(juce::Colour::fromString("FF22C55E")); // 緑
+        g.strokePath(pathToDraw, juce::PathStrokeType(1.5f));
+    }
+
+    // 再生位置インジケーター
+    if (audioEngine.hasRecordedAudio())
+    {
+        double pos = audioEngine.getPlaybackPosition();
+        float x = bounds.getX() + static_cast<float>(pos) * bounds.getWidth();
+
+        g.setColour(juce::Colours::white);
+        g.drawLine(x, bounds.getY(), x, bounds.getBottom(), 2.0f);
+    }
 }
+
+// ---------------------------------------------------------------------------
+// resized — mark that a rebuild is needed (size changed)
+// ---------------------------------------------------------------------------
 
 void WaveformComponent::resized()
 {
-	updateWaveformPath();
+    // Invalidate cached dimensions so next timer tick triggers a rebuild
+    {
+        juce::SpinLock::ScopedLockType lock(cacheLock);
+        activeCache.componentWidth  = 0;
+        activeCache.componentHeight = 0;
+    }
+    rebuildWaveformPathAsync();
 }
+
+// ---------------------------------------------------------------------------
+// timerCallback — lightweight: only repaints, schedules async rebuild if needed
+// ---------------------------------------------------------------------------
 
 void WaveformComponent::timerCallback()
 {
-	// 録音中または再生中は再描画
-	if (audioEngine.isRecording() || audioEngine.isPlaying())
-	{
-		// 録音中は波形を更新
-		if (audioEngine.isRecording())
-		{
-			int currentSamples = audioEngine.getRecordedSamplesCount();
-			if (currentSamples != cachedBufferSize)
-			{
-				updateWaveformPath();
-			}
-		}
-		repaint();
-	}
+    if (audioEngine.isRecording() || audioEngine.isPlaying())
+    {
+        if (audioEngine.isRecording())
+        {
+            int currentSamples = audioEngine.getRecordedSamplesCount();
+
+            // サンプル数がしきい値を超えたら非同期で再構築
+            if (std::abs(currentSamples - lastRebuiltSampleCount) >= REBUILD_THRESHOLD_SAMPLES
+                || currentSamples != cachedBufferSize)
+            {
+                rebuildWaveformPathAsync();
+            }
+        }
+
+        // Check for pending path swap (from background thread completion)
+        {
+            juce::SpinLock::ScopedLockType lock(cacheLock);
+            if (pendingCache.sampleCount > 0)
+            {
+                activeCache = std::move(pendingCache);
+                pendingCache = {};
+            }
+        }
+
+        repaint();
+    }
 }
 
-void WaveformComponent::changeListenerCallback(juce::ChangeBroadcaster* source)
+// ---------------------------------------------------------------------------
+// changeListenerCallback — recording state changed (start/stop)
+// ---------------------------------------------------------------------------
+
+void WaveformComponent::changeListenerCallback(juce::ChangeBroadcaster* /*source*/)
 {
-	// 録音状態が変わったら波形を更新
-	updateWaveformPath();
-	repaint();
+    if (!audioEngine.isRecording())
+    {
+        // 録音完了：最終波形を非同期で完全再構築
+        lastRebuiltSampleCount = 0; // force rebuild
+        rebuildWaveformPathAsync();
+    }
+    else
+    {
+        // 録音開始：キャッシュをクリア
+        lastRebuiltSampleCount = 0;
+        {
+            juce::SpinLock::ScopedLockType lock(cacheLock);
+            activeCache = {};
+            pendingCache = {};
+        }
+    }
+    repaint();
 }
+
+// ---------------------------------------------------------------------------
+// setExpanded
+// ---------------------------------------------------------------------------
 
 void WaveformComponent::setExpanded(bool shouldExpand)
 {
-	isExpanded = shouldExpand;
-	resized();
+    isExpanded = shouldExpand;
+    resized();
 }
 
-void WaveformComponent::updateWaveformPath()
+// ---------------------------------------------------------------------------
+// rebuildWaveformPathAsync — dispatches work to a background thread
+// ---------------------------------------------------------------------------
+
+void WaveformComponent::rebuildWaveformPathAsync()
 {
-	waveformPath.clear();
-	
-	const auto& buffer = audioEngine.getRecordedBuffer();
-	int numSamples = audioEngine.getRecordedSamplesCount(); // 実際に録音されたサンプル数を使用
-	
-	if (numSamples <= 0) return;
-	
-	auto bounds = getLocalBounds().toFloat().reduced(2);
-	float width = bounds.getWidth();
-	float height = bounds.getHeight();
-	float centerY = bounds.getCentreY();
-	
-	// サンプリングレートを調整（効率のため）
-	int samplesPerPixel = juce::jmax(1, numSamples / static_cast<int>(width));
-	
-	const float* channelData = buffer.getReadPointer(0);
-	
-	waveformPath.startNewSubPath(bounds.getX(), centerY);
-	
-	for (int x = 0; x < static_cast<int>(width); ++x)
-	{
-		int startSample = x * samplesPerPixel;
-		int endSample = juce::jmin(startSample + samplesPerPixel, numSamples);
-		
-		float maxValue = 0.0f;
-		for (int i = startSample; i < endSample; ++i)
-		{
-			maxValue = juce::jmax(maxValue, std::abs(channelData[i]));
-		}
-		
-		float y = centerY - maxValue * (height / 2.0f) * 0.9f;
-		waveformPath.lineTo(bounds.getX() + static_cast<float>(x), y);
-	}
-	
-	// 下半分（ミラー）
-	for (int x = static_cast<int>(width) - 1; x >= 0; --x)
-	{
-		int startSample = x * samplesPerPixel;
-		int endSample = juce::jmin(startSample + samplesPerPixel, numSamples);
-		
-		float maxValue = 0.0f;
-		for (int i = startSample; i < endSample; ++i)
-		{
-			maxValue = juce::jmax(maxValue, std::abs(channelData[i]));
-		}
-		
-		float y = centerY + maxValue * (height / 2.0f) * 0.9f;
-		waveformPath.lineTo(bounds.getX() + static_cast<float>(x), y);
-	}
-	
-	waveformPath.closeSubPath();
-	
-	cachedBufferSize = numSamples;
+    // Capture current dimensions and sample count (message thread)
+    const int numSamples = audioEngine.getRecordedSamplesCount();
+    if (numSamples <= 0) return;
+
+    const float compWidth  = static_cast<float>(getWidth());
+    const float compHeight = static_cast<float>(getHeight());
+    if (compWidth <= 0 || compHeight <= 0) return;
+
+    // Capture buffer snapshot for thread safety
+    // AudioBuffer::makeCopyOf creates a safe snapshot the background thread can read
+    const auto bufferSnapshot = audioEngine.getRecordedBuffer();
+    const int channels = bufferSnapshot.getNumChannels();
+
+    // Store rebuild target so we don't re-trigger unnecessarily
+    lastRebuiltSampleCount = numSamples;
+    cachedBufferSize = numSamples;
+
+    // Launch background computation via juce::ThreadPool
+    // Using a raw thread for simplicity — lifetime is bounded by the lambda captures
+    juce::Thread::launch([this, bufferSnapshot, numSamples, compWidth, compHeight, channels]()
+    {
+        // --- Heavy computation runs HERE (background thread) ---
+
+        juce::Path newPath;
+        auto bounds = juce::Rectangle<float>(0, 0, compWidth, compHeight).reduced(2);
+        float width  = bounds.getWidth();
+        float height = bounds.getHeight();
+        float centerY = bounds.getCentreY();
+
+        // Samples per pixel (decimation)
+        int samplesPerPixel = juce::jmax(1, numSamples / static_cast<int>(width));
+
+        // --- Top half ---
+        const float* channelData = bufferSnapshot.getReadPointer(0);
+
+        newPath.startNewSubPath(bounds.getX(), centerY);
+
+        for (int x = 0; x < static_cast<int>(width); ++x)
+        {
+            int startSample = x * samplesPerPixel;
+            int endSample   = juce::jmin(startSample + samplesPerPixel, numSamples);
+
+            float maxValue = 0.0f;
+            for (int i = startSample; i < endSample; ++i)
+            {
+                float v = std::abs(channelData[i]);
+                if (v > maxValue) maxValue = v;
+            }
+
+            float y = centerY - maxValue * (height / 2.0f) * 0.9f;
+            newPath.lineTo(bounds.getX() + static_cast<float>(x), y);
+        }
+
+        // --- Bottom half (mirror) ---
+        for (int x = static_cast<int>(width) - 1; x >= 0; --x)
+        {
+            int startSample = x * samplesPerPixel;
+            int endSample   = juce::jmin(startSample + samplesPerPixel, numSamples);
+
+            float maxValue = 0.0f;
+            for (int i = startSample; i < endSample; ++i)
+            {
+                float v = std::abs(channelData[i]);
+                if (v > maxValue) maxValue = v;
+            }
+
+            float y = centerY + maxValue * (height / 2.0f) * 0.9f;
+            newPath.lineTo(bounds.getX() + static_cast<float>(x), y);
+        }
+
+        newPath.closeSubPath();
+
+        // --- Swap the pending cache (thread-safe) ---
+        {
+            juce::SpinLock::ScopedLockType lock(this->cacheLock);
+            this->pendingCache.path         = std::move(newPath);
+            this->pendingCache.sampleCount  = numSamples;
+            this->pendingCache.componentWidth  = compWidth;
+            this->pendingCache.componentHeight = compHeight;
+        }
+        // The next timerCallback() will detect pendingCache.sampleCount > 0
+        // and swap it into activeCache on the message thread.
+    });
 }
 
+// ---------------------------------------------------------------------------
+// rebuildWaveformPathFromThumbnail — alternative using AudioThumbnail
+// (called when a file is loaded and the thumbnail is available)
+// ---------------------------------------------------------------------------
+
+void WaveformComponent::rebuildWaveformPathFromThumbnail()
+{
+    auto& thumbnail = audioEngine.getThumbnail();
+    if (!thumbnail.isFullyLoaded()) return;
+
+    const int numSamples = audioEngine.getRecordedSamplesCount();
+    if (numSamples <= 0) return;
+
+    auto bounds = getLocalBounds().toFloat().reduced(2);
+    float width  = bounds.getWidth();
+    float height = bounds.getHeight();
+    float centerY = bounds.getCentreY();
+
+    juce::Path newPath;
+    const double thumbnailLength = thumbnail.getTotalLength();
+    if (thumbnailLength <= 0) return;
+
+    newPath.startNewSubPath(bounds.getX(), centerY);
+
+    // AudioThumbnail provides min/max per pixel — extremely fast
+    for (int x = 0; x < static_cast<int>(width); ++x)
+    {
+        float timeAtX = static_cast<double>(x) / width * thumbnailLength;
+        float maxVal  = thumbnail.getMaxValueAtTime(timeAtX);
+
+        float y = centerY - maxVal * (height / 2.0f) * 0.9f;
+        newPath.lineTo(bounds.getX() + static_cast<float>(x), y);
+    }
+
+    // Bottom mirror
+    for (int x = static_cast<int>(width) - 1; x >= 0; --x)
+    {
+        float timeAtX = static_cast<double>(x) / width * thumbnailLength;
+        float maxVal  = thumbnail.getMaxValueAtTime(timeAtX);
+
+        float y = centerY + maxVal * (height / 2.0f) * 0.9f;
+        newPath.lineTo(bounds.getX() + static_cast<float>(x), y);
+    }
+
+    newPath.closeSubPath();
+
+    // Direct write to active cache (called from message thread context)
+    {
+        juce::SpinLock::ScopedLockType lock(cacheLock);
+        activeCache.path         = std::move(newPath);
+        activeCache.sampleCount  = numSamples;
+        activeCache.componentWidth  = static_cast<float>(getWidth());
+        activeCache.componentHeight = static_cast<float>(getHeight());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rebuildWaveformPathFromBuffer — synchronous fallback (message thread)
+// Use sparingly: only for small buffers or non-recording contexts
+// ---------------------------------------------------------------------------
+
+void WaveformComponent::rebuildWaveformPathFromBuffer()
+{
+    const auto& buffer = audioEngine.getRecordedBuffer();
+    int numSamples = audioEngine.getRecordedSamplesCount();
+    if (numSamples <= 0) return;
+
+    auto bounds = getLocalBounds().toFloat().reduced(2);
+    float width  = bounds.getWidth();
+    float height = bounds.getHeight();
+    float centerY = bounds.getCentreY();
+
+    int samplesPerPixel = juce::jmax(1, numSamples / static_cast<int>(width));
+    const float* channelData = buffer.getReadPointer(0);
+
+    juce::Path newPath;
+    newPath.startNewSubPath(bounds.getX(), centerY);
+
+    for (int x = 0; x < static_cast<int>(width); ++x)
+    {
+        int startSample = x * samplesPerPixel;
+        int endSample   = juce::jmin(startSample + samplesPerPixel, numSamples);
+
+        float maxValue = 0.0f;
+        for (int i = startSample; i < endSample; ++i)
+            maxValue = juce::jmax(maxValue, std::abs(channelData[i]));
+
+        float y = centerY - maxValue * (height / 2.0f) * 0.9f;
+        newPath.lineTo(bounds.getX() + static_cast<float>(x), y);
+    }
+
+    for (int x = static_cast<int>(width) - 1; x >= 0; --x)
+    {
+        int startSample = x * samplesPerPixel;
+        int endSample   = juce::jmin(startSample + samplesPerPixel, numSamples);
+
+        float maxValue = 0.0f;
+        for (int i = startSample; i < endSample; ++i)
+            maxValue = juce::jmax(maxValue, std::abs(channelData[i]));
+
+        float y = centerY + maxValue * (height / 2.0f) * 0.9f;
+        newPath.lineTo(bounds.getX() + static_cast<float>(x), y);
+    }
+
+    newPath.closeSubPath();
+
+    {
+        juce::SpinLock::ScopedLockType lock(cacheLock);
+        activeCache.path         = std::move(newPath);
+        activeCache.sampleCount  = numSamples;
+        activeCache.componentWidth  = static_cast<float>(getWidth());
+        activeCache.componentHeight = static_cast<float>(getHeight());
+    }
+
+    cachedBufferSize = numSamples;
+}

--- a/Source/WaveformComponent.h
+++ b/Source/WaveformComponent.h
@@ -21,13 +21,32 @@ class WaveformComponent : public juce::Component,
 	void changeListenerCallback(juce::ChangeBroadcaster* source) override;
 
 	void setExpanded(bool shouldExpand);
-	void updateWaveformPath();
 
 	private:
+	// --- Waveform path generation (runs off UI thread) ---
+	void rebuildWaveformPathAsync();
+	void rebuildWaveformPathFromThumbnail();
+	void rebuildWaveformPathFromBuffer();
+
+	// --- Thread-safe cached path swap ---
+	struct WaveformCache
+	{
+		juce::Path path;
+		int sampleCount = 0;     // sample count this path was built for
+		float componentWidth = 0;
+		float componentHeight = 0;
+	};
+	juce::SpinLock cacheLock;
+	WaveformCache activeCache;
+	WaveformCache pendingCache;
+
 	AudioEngine& audioEngine;
 	bool isExpanded = false;
-	juce::Path waveformPath;
 	int cachedBufferSize = 0;
+
+	// Incremental recording tracking: only rebuild when samples changed significantly
+	int lastRebuiltSampleCount = 0;
+	static constexpr int REBUILD_THRESHOLD_SAMPLES = 4096; // rebuild every ~4K new samples
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WaveformComponent)
 };


### PR DESCRIPTION
## Summary

Closes #5 — 波形描画がUIスレッドをブロックする問題を修正しました。

## Problem

30秒録音（44.1kHz）で約130万サンプルを25fpsのタイマーコールバック（メッセージスレッド）で毎回スキャンし、UIがフリーズしていました。

```
timerCallback() → updateWaveformPath() → 1.3Mサンプル全件走査 (UIスレッド上)
```

## Solution

### 1. バックグラウンドスレッドでのPath計算
- `juce::Thread::launch()` を使用して波形Pathの構築をバックグラウンドスレッドに移動
- メッセージスレッドでは軽いPathのスワップのみ実行

### 2. ダブルバッファ + SpinLock
- `activeCache` / `pendingCache` の2バッファ方式で `paint()` とバックグラウンド計算を分離
- `juce::SpinLock` でスレッドセーフなキャッシュスワップを実現
- `paint()` はロック取得後に即座にコピーを取得して描画

### 3. 差分更新の最適化
- `REBUILD_THRESHOLD_SAMPLES = 4096` — 新規サンプルが4K未満なら再構築をスキップ
- 録音完了時の一度だけ完全再構築

### 4. 将来のAudioThumbnail対応
- `rebuildWaveformPathFromThumbnail()` メソッドを追加
- `juce::AudioThumbnail`（AudioEngineで既に初期化済み）を活用する準備

## Changes

| File | Change |
|------|--------|
| `WaveformComponent.h` | ダブルバッファ構造・非同期メソッド宣言 |
| `WaveformComponent.cpp` | Path計算をバックグラウンドスレッド化・SpinLock対応 |

## Testing

- [ ] Xcode/macOSでビルド確認
- [ ] 30秒録音中のUI応答性を確認（カクつきが解消されたか）
- [ ] 録音完了後の波形表示が正しく描画されるか
- [ ] リサイズ時の波形再描画が正常動作するか