### PR TITLE
fix: ステージのアスペクト比をレスポンシブに対応

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -175,6 +175,8 @@ void MainComponent::resized()
 	auto area = getLocalBounds();
 	const int width = getWidth();
 	const int height = getHeight();
+	const bool isPortrait = height > width; // 縦長画面の判定
+	const float aspectRatio = static_cast<float>(width) / static_cast<float>(height);
 
 	// 【レスポンシブ設定】画面サイズに応じたパラメータ
 	const int headerHeight = juce::jmax(50, height / 15);  // 最低50px、高さの1/15
@@ -200,7 +202,15 @@ void MainComponent::resized()
 	// ライブラリ表示/非表示
 	if (isLibraryOpen)
 	{
-		sampleList->setBounds(area.removeFromRight(sidebarWidth));
+		if (isPortrait)
+		{
+			// 縦画面ではライブラリを下部から展開
+			sampleList->setBounds(area.removeFromBottom(sidebarWidth));
+		}
+		else
+		{
+			sampleList->setBounds(area.removeFromRight(sidebarWidth));
+		}
 	}
 	else
 	{
@@ -217,22 +227,59 @@ void MainComponent::resized()
 		audioSelector->setBounds(0, 0, 0, 0);
 	}
 
-	// 残りのエリアを分割
-	auto bottomControl = area.removeFromBottom(bottomControlHeight);
-	
-	// クロスフェーダーを中央に配置（幅は1/3、高さは1.5倍）
-	const int crossfaderActualHeight = static_cast<int>(crossfaderHeight * 1.5f);
-	auto crossfaderArea = bottomControl.removeFromBottom(crossfaderActualHeight);
-	const int crossfaderWidth = juce::jmin(crossfaderArea.getWidth() / 2, 350); // 幅1/2、最大350px
-	crossfader->setBounds(crossfaderArea.withSizeKeepingCentre(crossfaderWidth, crossfaderActualHeight - 6));
+	if (isPortrait)
+	{
+		// 【縦画面レイアウト】ターンテーブルを正方形に近いアスペクト比で上部に配置
+		// ターンテーブルのサイズを画面幅に基づいて制限（円形レコードの表示に最適化）
+		const int turntableSize = juce::jmin(area.getWidth(), static_cast<int>(area.getWidth() * 1.1f));
+		auto turntableArea = area.removeFromTop(turntableSize);
+		turntable->setBounds(turntableArea);
 
-	waveform->setBounds(bottomControl); // 波形表示
-	
-	// サンプルスロットを左側に配置
-	const int slotWidth = juce::jmax(80, width / 12);
-	sampleSlots->setBounds(area.removeFromLeft(slotWidth));
-	
-	turntable->setBounds(area); // 残りをターンテーブルに
+		// サンプルスロットをターンテーブルの下に水平配置（縦画面用）
+		const int slotHeight = juce::jmax(40, height / 18);
+		sampleSlots->setBounds(area.removeFromTop(slotHeight));
+
+		// 下部コントロールエリア（波形 + クロスフェーダー）
+		auto bottomControl = area;
+
+		// クロスフェーダーを下部に配置
+		const int crossfaderActualHeight = static_cast<int>(crossfaderHeight * 1.5f);
+		auto crossfaderArea = bottomControl.removeFromBottom(crossfaderActualHeight);
+		const int crossfaderWidth = juce::jmin(crossfaderArea.getWidth() / 2, 350);
+		crossfader->setBounds(crossfaderArea.withSizeKeepingCentre(crossfaderWidth, crossfaderActualHeight - 6));
+
+		waveform->setBounds(bottomControl); // 残りを波形表示に
+	}
+	else
+	{
+		// 【横画面レイアウト（既存ロジック + アスペクト比改善）】
+		// 残りのエリアを分割
+		auto bottomControl = area.removeFromBottom(bottomControlHeight);
+
+		// クロスフェーダーを中央に配置（幅は1/3、高さは1.5倍）
+		const int crossfaderActualHeight = static_cast<int>(crossfaderHeight * 1.5f);
+		auto crossfaderArea = bottomControl.removeFromBottom(crossfaderActualHeight);
+		const int crossfaderWidth = juce::jmin(crossfaderArea.getWidth() / 2, 350);
+		crossfader->setBounds(crossfaderArea.withSizeKeepingCentre(crossfaderWidth, crossfaderActualHeight - 6));
+
+		waveform->setBounds(bottomControl); // 波形表示
+
+		// サンプルスロットを左側に配置
+		const int slotWidth = juce::jmax(80, width / 12);
+		sampleSlots->setBounds(area.removeFromLeft(slotWidth));
+
+		// アスペクト比に応じたターンテーブル領域の最適化
+		// 狭い横画面（ aspectRatio < 1.0 の正方形付近）ではターンテーブルを正方形に近づける
+		if (aspectRatio < 1.2f)
+		{
+			const int side = juce::jmin(area.getWidth(), area.getHeight());
+			turntable->setBounds(area.withSizeKeepingCentre(side, side));
+		}
+		else
+		{
+			turntable->setBounds(area);
+		}
+	}
 }
 
 void MainComponent::buttonClicked(juce::Button* button)

--- a/Source/SampleSlotComponent.cpp
+++ b/Source/SampleSlotComponent.cpp
@@ -44,23 +44,40 @@ SampleSlotComponent::~SampleSlotComponent()
 void SampleSlotComponent::paint(juce::Graphics& g)
 {
     g.fillAll(juce::Colour::fromString("FF1E293B"));
-    
-    // タイトル
-    g.setColour(juce::Colours::white);
-    g.setFont(juce::FontOptions(14.0f).withStyle("Bold"));
-    g.drawText("SLOTS", getLocalBounds().removeFromTop(25), juce::Justification::centred);
+
+    // タイトルは縦配置モード（横画面）でのみ表示
+    const bool isHorizontal = getWidth() > getHeight() * 2;
+    if (!isHorizontal)
+    {
+        g.setColour(juce::Colours::white);
+        g.setFont(juce::FontOptions(14.0f).withStyle("Bold"));
+        g.drawText("SLOTS", getLocalBounds().removeFromTop(25), juce::Justification::centred);
+    }
 }
 
 void SampleSlotComponent::resized()
 {
     auto area = getLocalBounds().reduced(5);
-    area.removeFromTop(25); // タイトルスペース
-    
-    int slotHeight = area.getHeight() / NUM_SLOTS;
-    
-    for (int i = 0; i < NUM_SLOTS; ++i)
+    const bool isHorizontal = area.getWidth() > area.getHeight() * 2; // 幅が高さの2倍以上なら横配置
+
+    if (isHorizontal)
     {
-        slotButtons[static_cast<size_t>(i)].setBounds(area.removeFromTop(slotHeight).reduced(2));
+        // 横配置モード（縦画面レイアウト用）：スロットを横一列に並べる
+        for (int i = 0; i < NUM_SLOTS; ++i)
+        {
+            slotButtons[static_cast<size_t>(i)].setBounds(area.removeFromLeft(area.getWidth() / (NUM_SLOTS - i)).reduced(2));
+        }
+    }
+    else
+    {
+        // 縦配置モード（従来の横画面レイアウト用）
+        area.removeFromTop(25); // タイトルスペース
+        int slotHeight = area.getHeight() / NUM_SLOTS;
+        
+        for (int i = 0; i < NUM_SLOTS; ++i)
+        {
+            slotButtons[static_cast<size_t>(i)].setBounds(area.removeFromTop(slotHeight).reduced(2));
+        }
     }
 }
 

--- a/Source/TurntableComponent.cpp
+++ b/Source/TurntableComponent.cpp
@@ -25,15 +25,13 @@ void TurntableComponent::paint(juce::Graphics& g)
 
 	// --- 描画エリアの計算 ---
 	auto area = getLocalBounds().toFloat();
-	// アーム用のスペースを確保するため、上部に余白を設ける
-	auto discBounds = area.reduced(60, 40);
 
-	// レコードのサイズを少し小さくしてアームのスペースを確保
-	float diameter = juce::jmin(discBounds.getWidth(), discBounds.getHeight()) * 0.85f;
+	// レコード盤を正方形領域に収める（アスペクト比に依存しない）
+	float diameter = juce::jmin(area.getWidth(), area.getHeight()) * 0.85f;
 	float radius = diameter / 2.0f;
-	auto center = discBounds.getCentre();
+	auto center = area.getCentre();
 
-	// レコード盤の正円領域
+	// 正方形のディスク領域を中央に配置
 	juce::Rectangle<float> discArea(center.x - radius, center.y - radius, diameter, diameter);
 
 	// --- 2. レコード盤の描画（リッチバージョン） ---
@@ -118,18 +116,20 @@ void TurntableComponent::paint(juce::Graphics& g)
 	g.restoreState();
 
 	// センターホール（メタリック）
+	float holeSize = juce::jmax(radius * 0.06f, 4.0f);
 	g.setColour(juce::Colour::fromString("FF444444"));
-	g.fillEllipse(center.x - 6, center.y - 6, 12, 12);
+	g.fillEllipse(center.x - holeSize, center.y - holeSize, holeSize * 2, holeSize * 2);
 	g.setColour(juce::Colours::black);
-	g.fillEllipse(center.x - 3, center.y - 3, 6, 6);
+	g.fillEllipse(center.x - holeSize * 0.5f, center.y - holeSize * 0.5f, holeSize, holeSize);
 
 
 	// --- 4. トーンアームの追加描画（リッチバージョン） ---
 
-	juce::Point<float> pivotCenter(discArea.getX() - 30.0f, discArea.getY() - 30.0f);
-	float pivotRadius = 20.0f;
+	// ピボットをディスク外周の左上に配置（アスペクト比に依存しない）
+	juce::Point<float> pivotCenter(discArea.getX() - radius * 0.15f, discArea.getY() - radius * 0.15f);
+	float pivotRadius = juce::jmax(radius * 0.1f, 12.0f);
 	float armLength = radius * 1.3f;
-	float armWidth = 12.0f;
+	float armWidth = juce::jmax(radius * 0.08f, 8.0f);
 
 	float armAngle;
 	if (audioEngine.isPlaying() || isDragging) {
@@ -158,7 +158,7 @@ void TurntableComponent::paint(juce::Graphics& g)
 	g.drawLine(armLine, armWidth);
 
 	// カートリッジ（リッチ版）
-	float cartLength = 30.0f;
+	float cartLength = radius * 0.2f;
 	float cartWidth = armWidth * 1.2f;
 	
 	g.saveState();
@@ -274,8 +274,9 @@ void TurntableComponent::setExpanded(bool shouldExpand)
 float TurntableComponent::getAngleFromPoint(juce::Point<float> p)
 {
 	auto area = getLocalBounds().toFloat();
-	auto discBounds = area.removeFromLeft(area.getWidth() * 0.85f).reduced(10);
-	auto center = discBounds.getCentre();
+	float diameter = juce::jmin(area.getWidth(), area.getHeight()) * 0.85f;
+	float radius = diameter / 2.0f;
+	auto center = area.getCentre();
 	return std::atan2(p.y - center.y, p.x - center.x);
 }
 


### PR DESCRIPTION
## Summary

ステージ（ターンテーブル）のアスペクト比をレスポンシブに対応しました。
縦画面（スマホ）と横画面（タブレット/PC）で最適なレイアウトに自動切替します。

## Changes

### MainComponent.cpp
- 縦画面/横画面の判定（`isPortrait`）を追加
- **縦画面**: ターンテーブルを上部に配置（画面幅ベースで正方形に近いサイズ）、サンプルスロットを水平一列でターンテーブル下に配置、波形＋クロスフェーダーを下部に配置
- **横画面**: 既存レイアウトを維持しつつ、アスペクト比 < 1.2 の正方形付近ではターンテーブル領域を正方形に制限
- ライブラリパネルを縦画面では下部から展開するように変更

### TurntableComponent.cpp
- ディスク描画エリアを `getLocalBounds()` 中央に `jmin(w,h)` ベースで配置（固定オフセット廃止）
- トーンアームのピボット位置をディスク外周からの相対座標に変更（ハードコード `-30` 廃止）
- アーム幅、カートリッジサイズ、センターホールサイズを `radius` 比例にスケーリング

### SampleSlotComponent.cpp
- 幅が高さの2倍以上の場合は横配置（横一列）に自動切替
- 縦配置モード時のみ「SLOTS」タイトルを表示

## Testing
- 縦画面（ portrait ）: ターンテーブルが正方形に近い領域に描画されることを確認
- 横画面（ landscape ）: 従来レイアウトを維持、正方形付近ではターンテーブルが正方形に制限されることを確認
- ※ JUCEビルド環境が利用できないため、コードレビューのみ実施

Fixes happytown-s/ScratchMyVoice#14